### PR TITLE
frontend: Add Navbar

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "fix-format": "prettier --write src"
   },
   "dependencies": {
+    "@heroicons/react": "^2.1.3",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
     "react": "^18.2.0",

--- a/frontend/src/Navbar.tsx
+++ b/frontend/src/Navbar.tsx
@@ -1,7 +1,0 @@
-import './index.css';
-
-function Navbar() {
-    return <div className="flex flex-row">Navbar</div>;
-}
-
-export default Navbar;

--- a/frontend/src/library/Navbar.tsx
+++ b/frontend/src/library/Navbar.tsx
@@ -1,0 +1,50 @@
+import { Link } from 'react-router-dom';
+import { useState } from 'react';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/solid';
+import { NavbarLink } from '../pages/AppLayout';
+
+function NavbarItem({ link }: { link: NavbarLink }) {
+    return (
+        <Link
+            to={link.path}
+            className="text-[#ECD407] font-bold text-xl hover:underline"
+        >
+            {link.label}
+        </Link>
+    );
+}
+
+function Navbar({ links }: { links: NavbarLink[] }) {
+    const [menuOpen, setMenuOpen] = useState(false);
+
+    return (
+        <div className="flex flex-row sticky top-0 bg-[#D72600] p-3 shadow-md justify-between items-center">
+            <div className="text-[#ECD407] tracking-tight font-black text-4xl drop-shadow-[-7px_0px_0px_rgba(0,0,0,1)]">
+                <Link to="/">UNO</Link>
+            </div>
+            <div className="hidden md:flex space-x-4">
+                {links.map((link, index) => (
+                    <NavbarItem key={index} link={link} />
+                ))}
+            </div>
+            <div className="md:hidden flex items-center">
+                <button onClick={() => setMenuOpen(!menuOpen)}>
+                    {menuOpen ? (
+                        <XMarkIcon className="w-5 h-5 text-[#ECD407]" />
+                    ) : (
+                        <Bars3Icon className="w-6 h-6 text-[#ECD407]" />
+                    )}
+                </button>
+            </div>
+            {menuOpen && (
+                <div className="absolute top-16 left-0 w-full bg-[#D72600] p-3 flex flex-col space-y-4 md:hidden">
+                    {links.map((link, index) => (
+                        <NavbarItem key={index} link={link} />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default Navbar;

--- a/frontend/src/pages/AppLayout.tsx
+++ b/frontend/src/pages/AppLayout.tsx
@@ -1,10 +1,19 @@
 import { Outlet } from 'react-router-dom';
-import Navbar from '../Navbar';
+import Navbar from '../library/Navbar';
+
+export type NavbarLink = {
+    path: string;
+    label: string;
+};
 
 function AppLayout() {
+    const links: NavbarLink[] = [
+        { path: '/about', label: 'About' },
+        { path: '/play', label: 'Play' },
+    ];
     return (
         <div>
-            <Navbar />
+            <Navbar links={links} />
             <Outlet />
             {/* todo: Add a footer component */}
         </div>


### PR DESCRIPTION
This adds a UNO themed navbar to the frontend. The navbar is responsive and collapses into a hamburger menu on smaller screens.

It can have multiple links, which can be defined on use.

Fixes #19 

## Description
Adds a Navigation Bar, (and removes some unnecessary css previously present, only using tailwind)

## Motivation and Context
The design uses the UNO Red Color, and the logo is styled like the UNO Logo.

## Checklist
- [x] I have tested these changes locally.
- [ ] I have reviewed the code and ensured it follows the project's coding guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have assigned reviewers to this pull request.

## Screenshots (if applicable)
![image](https://github.com/shivansh-bhatnagar18/multiplayer-uno/assets/40538506/675cdb13-b27e-4181-8a9a-3c974711bb9e)
![image](https://github.com/shivansh-bhatnagar18/multiplayer-uno/assets/40538506/23c9db14-61b9-4b47-a140-8594da92b419)
