### PR TITLE
server:Add game event handler for JOIN_GAME event

### DIFF
--- a/backend/src/uno-game-engine/events/joinGame.ts
+++ b/backend/src/uno-game-engine/events/joinGame.ts
@@ -1,0 +1,12 @@
+import { assert } from 'console';
+import { GameEngine } from '../engine';
+import { registerEventHandler } from '../gameEvents';
+
+export function joinGame(game: GameEngine, event: GameEvent): EventResult {
+    assert(event.type === 'JOIN_GAME', 'Invalid event type');
+    const player: Player = { id: event.playerId, cards: [] };
+    game.addPlayer(player);
+    return { type: 'SUCCESS', message: 'player joined successfully' };
+}
+
+registerEventHandler('JOIN_GAME', joinGame);


### PR DESCRIPTION
# Fixes: #93 

## Description
Created the event handler for JOIN_GAME event to let new players join the server before the game is started by the host.

## Checklist
- [x] I have tested these changes locally.
- [x] I have reviewed the code and ensured it follows the project's coding guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have assigned reviewers to this pull request.

