### PR TITLE
server:Add game event handler for LEAVE_GAME event

### DIFF
--- a/backend/src/types.d.ts
+++ b/backend/src/types.d.ts
@@ -27,7 +27,7 @@ type EventResult = {
     message: string;
 };
 
-type GameEventType = 'DRAW_CARD' | 'THROW_CARD' | 'JOIN_GAME';
+type GameEventType = 'DRAW_CARD' | 'THROW_CARD' | 'JOIN_GAME' | 'LEAVE_GAME';
 
 type GameEvent =
     | {
@@ -46,6 +46,11 @@ type GameEvent =
       }
     | {
           type: 'JOIN_GAME';
+          playerId: string;
+          data: null;
+      }
+    | {
+          type: 'LEAVE_GAME';
           playerId: string;
           data: null;
       };

--- a/backend/src/uno-game-engine/engine.ts
+++ b/backend/src/uno-game-engine/engine.ts
@@ -48,6 +48,14 @@ export class GameEngine {
             (this.players.length + this.currentPlayerIndex + this.direction) %
             this.players.length;
     }
+
+    removePlayer(player: Player) {
+        this.cardDeck.push(...player.cards);
+        shuffle(this.cardDeck);
+        const index = this.players.indexOf(player);
+        this.players.splice(index, 1);
+    }
+
     drawCardFromDeck(player: Player, numCards = 1): EventResult {
         try {
             if (this.cardDeck.length < numCards) {

--- a/backend/src/uno-game-engine/events/leaveGame.ts
+++ b/backend/src/uno-game-engine/events/leaveGame.ts
@@ -1,0 +1,15 @@
+import { assert } from 'console';
+import { GameEngine } from '../engine';
+import { getPlayer, registerEventHandler } from '../gameEvents';
+
+export function leaveGame(game: GameEngine, event: GameEvent): EventResult {
+    assert(event.type === 'LEAVE_GAME', 'Invalid event type');
+    const player = getPlayer(game, event.playerId);
+    if (!player) {
+        return { type: 'ERROR', message: 'Player not found' };
+    }
+    game.removePlayer(player);
+    return { type: 'SUCCESS', message: 'player left successfully' };
+}
+
+registerEventHandler('LEAVE_GAME', leaveGame);


### PR DESCRIPTION
# fixes:#94

## Description
Created the LEAVE_GAME event handler which removes the player from the current game then takes the card that the player has then puts it in the deck and shuffles the deck for the current players to continue their game.

## Checklist
- [x] I have tested these changes locally.
- [x] I have reviewed the code and ensured it follows the project's coding guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have assigned reviewers to this pull request.


