### PR TITLE
Client:Enable closing modals using the ESC key

### DIFF
--- a/frontend/src/library/modal.tsx
+++ b/frontend/src/library/modal.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useContext } from 'react';
+import { useRef, useState, useContext, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from './button';
 import { ToastContext } from './toast/toast-context';
@@ -35,6 +35,22 @@ const Modal: React.FC<ModalProps> = ({ onClose }) => {
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setGameCode(e.target.value);
     };
+
+    const handleKeyDown = useCallback(
+        (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onClose();
+            }
+        },
+        [onClose]
+    );
+
+    useEffect(() => {
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [handleKeyDown]);
 
     return (
         <div

--- a/frontend/src/library/rulesModal.tsx
+++ b/frontend/src/library/rulesModal.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 interface ModalProps {
     onClose: () => void;
@@ -12,6 +12,21 @@ const RulesModal: React.FC<ModalProps> = ({ onClose }) => {
             onClose();
         }
     };
+    const handleKeyDown = useCallback(
+        (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onClose();
+            }
+        },
+        [onClose]
+    );
+
+    useEffect(() => {
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [handleKeyDown]);
 
     return (
         <div


### PR DESCRIPTION
# fixes:#109

## Description
added the ability to close the modal when you press the esc key without any side effects.

## Checklist
- [x] I have tested these changes locally.
- [x] I have reviewed the code and ensured it follows the project's coding guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have assigned reviewers to this pull request.
